### PR TITLE
Whitescape recognition has been changed in order to tolerate tabs too

### DIFF
--- a/jute.cpp
+++ b/jute.cpp
@@ -156,7 +156,7 @@ struct parser::token {
   token(string value="",token_type type=UNKNOWN): value(value), type(type) {}
 };
 bool parser::is_whitespace(const char c) {
-  return string(" \n\r  ").find(c) != string::npos;
+  return isspace(c);
 }
 int parser::next_whitespace(const string& source, int i) {
   while (i < (int)source.length()) {


### PR DESCRIPTION
I've replaced the whitespace recognition logic to [isspace()](http://www.cplusplus.com/reference/cctype/isspace/) in order to tolerate e.g. tab characters as well.
I didn't want to eliminate the is_whitespace() intentionally.